### PR TITLE
Correct typos in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,10 +4,10 @@ version = "0.1.0"
 edition = "2021"
 license = "MIT"
 description = "library that can read and write QIF (Quicken Interchange File)."
-homepage = "https://gthub.com/bryceac/qif_rs"
+homepage = "https://github.com/bryceac/qif_rs"
 readme = "README.mediawiki"
 repository = "https://github.com/bryceac/qif_rs"
-keywords = ["qif", "qicken", "files", "parsing", "reading"]
+keywords = ["qif", "quicken", "files", "parsing", "reading"]
 
 [dependencies]
 chrono = "0.4.40"


### PR DESCRIPTION
Besides these minor typos, also note that the [crates.io page for this crate](https://crates.io/crates/qif) shows HTML, which is hard to read.

<img width="537" alt="Screenshot 2025-03-21 at 14 07 40" src="https://github.com/user-attachments/assets/ca2b2c44-4d77-4412-b34e-a370c2917b77" />
